### PR TITLE
Clean up license framing and add code signing policy page

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -76,7 +76,7 @@
 
     <div class="section">
       <div class="section-label">Open Source</div>
-      <p>Source code is publicly available on <a href="https://github.com/Computer-Tsu" target="_blank" rel="noopener">GitHub</a>. Contributions are welcome — see the CONTRIBUTING.md in each repository for guidelines.</p>
+      <p>Some ShackDesk apps have public source code on <a href="https://github.com/Computer-Tsu" target="_blank" rel="noopener">GitHub</a>. PortPane is one of them, and contributions are welcome — see the CONTRIBUTING.md in each repository for guidelines.</p>
     </div>
 
     <hr style="margin-top: 3rem;">

--- a/faq/index.html
+++ b/faq/index.html
@@ -42,7 +42,7 @@
           </button>
           <div class="faq-answer">
             <p>Yes. The SmartScreen warning appears because ShackDesk apps are independently developed software that is new to Microsoft's reputation system. It is not an indication of a virus or malware. To proceed, click <strong>More info</strong> then <strong>Run anyway</strong>.</p>
-            <p>ShackDesk apps will be code-signed as the project matures, which will reduce and eventually eliminate this warning. In the meantime, you can verify the integrity of any download by checking the SHA-256 hash posted alongside each release on GitHub. Source code is publicly available for anyone who wants to inspect it: <a href="https://github.com/Computer-Tsu" target="_blank" rel="noopener">github.com/Computer-Tsu</a>.</p>
+            <p>ShackDesk is preparing code signing for PortPane, starting with alpha releases. See the <a href="/portpane/code-signing-policy/">PortPane code signing policy</a> for current status. In the meantime, you can verify the integrity of any download by checking the SHA-256 hash posted alongside each release on GitHub. PortPane source code is publicly available for anyone who wants to inspect it: <a href="https://github.com/Computer-Tsu/ShackDesk-PortPane" target="_blank" rel="noopener">github.com/Computer-Tsu/ShackDesk-PortPane</a>.</p>
           </div>
         </div>
 
@@ -192,7 +192,7 @@
             <svg class="faq-chevron" width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M4 6l4 4 4-4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
           </button>
           <div class="faq-answer">
-            <p>Yes. ShackDesk app source code is publicly available on GitHub. You are free to inspect, build, and contribute to the code. See each app's repository for license details.</p>
+            <p>Some ShackDesk apps are open source. PortPane source code is publicly available on GitHub under the MIT License. You are free to inspect, build, and contribute to that code. See each app's page or repository for current licensing details.</p>
           </div>
         </div>
 
@@ -212,7 +212,7 @@
             <svg class="faq-chevron" width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M4 6l4 4 4-4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
           </button>
           <div class="faq-answer">
-            <p>Yes. Personal and club use is covered under the standard license. See the license terms for each app on GitHub for details.</p>
+            <p>Yes. PortPane can be used by individual operators, clubs, and EMCOMM groups. ShackDesk also offers optional registration, personalization, and support for official builds.</p>
           </div>
         </div>
 

--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@
       <div class="section-label">Design Philosophy</div>
       <div class="card">
         <p>ShackDesk apps are <strong>offline-first</strong>. No internet connection required, no telemetry without your consent, no nagware. Designed to work in the field, at a club station, or on a go-kit laptop just as well as at your home shack.</p>
-        <p>Source code is publicly available on <a href="https://github.com/Computer-Tsu" target="_blank" rel="noopener">GitHub</a>. Contributions welcome.</p>
+        <p>Some ShackDesk apps are open source and published on <a href="https://github.com/Computer-Tsu" target="_blank" rel="noopener">GitHub</a>. Contributions welcome.</p>
       </div>
     </div>
 

--- a/portpane/code-signing-policy/index.html
+++ b/portpane/code-signing-policy/index.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="PortPane code signing policy — how official ShackDesk builds are produced, signed, and published.">
+  <title>PortPane Code Signing Policy — ShackDesk</title>
+  <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+
+  <nav class="nav">
+    <div class="nav-inner">
+      <a href="/" class="nav-logo">
+        <span class="nav-logo-dot"></span>ShackDesk
+      </a>
+      <ul class="nav-links">
+        <li><a href="/portpane/" class="active">PortPane</a></li>
+        <li><a href="/rigcheck/">RigCheck</a></li>
+        <li><a href="/markmyspot/">MarkMySpot</a></li>
+        <li><a href="/about/">About</a></li>
+        <li><a href="/faq/">FAQ</a></li>
+        <li><a href="/sponsor" class="nav-sponsor">&#9829; Sponsor</a></li>
+        <li><a href="/portpane/download" class="nav-cta">Download</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <main class="page">
+
+    <h1>PortPane Code Signing Policy</h1>
+    <p class="lead" style="margin-top: 1rem;">This page describes how official ShackDesk PortPane builds are produced, signed, and published.</p>
+
+    <div class="section">
+      <div class="section-label">Source Code and Official Builds</div>
+      <div class="card">
+        <p>PortPane source code is licensed under MIT and is published in the public GitHub repository.</p>
+        <p>Official ShackDesk builds, optional registration/personalization, and support are separate offerings. These services do not reduce or override MIT rights for the source code.</p>
+        <p style="margin-top: 0.75rem;"><a href="https://github.com/Computer-Tsu/ShackDesk-PortPane" target="_blank" rel="noopener">View the PortPane repository</a></p>
+      </div>
+    </div>
+
+    <div class="section">
+      <div class="section-label">Current Status</div>
+      <div class="card">
+        <p>PortPane release artifacts are currently unsigned unless a release explicitly states otherwise.</p>
+        <p>ShackDesk's initial signing rollout is planned for <strong>alpha</strong> releases first, then <strong>beta</strong>. Stable releases may later use the same process or a separate signing process.</p>
+      </div>
+    </div>
+
+    <div class="section">
+      <div class="section-label">Build and Release Process</div>
+      <div class="card">
+        <p>Official PortPane builds are produced from the public GitHub repository using GitHub Actions workflow runs.</p>
+        <p>Release artifacts are published to GitHub Releases together with SHA-256 hashes.</p>
+        <p>When code signing is enabled for a channel, release notes should identify which artifacts were signed and where users can verify current signing status.</p>
+      </div>
+    </div>
+
+    <div class="section">
+      <div class="section-label">Project Roles</div>
+      <div class="card">
+        <p>Project owner and release maintainer: <strong>Mark McDow (N4TEK)</strong>, My Computer Guru LLC.</p>
+        <p>Source code, release workflows, and public documentation are maintained in the PortPane GitHub repository.</p>
+      </div>
+    </div>
+
+    <div class="section">
+      <div class="section-label">Related Documents</div>
+      <div class="card">
+        <p><a href="/privacy/">Privacy Policy</a></p>
+        <p><a href="https://github.com/Computer-Tsu/ShackDesk-PortPane/blob/dev/CODE_SIGNING_POLICY.md" target="_blank" rel="noopener">Repository Code Signing Policy</a></p>
+        <p><a href="https://github.com/Computer-Tsu/ShackDesk-PortPane/blob/dev/LICENSE-MIT.md" target="_blank" rel="noopener">MIT License</a></p>
+        <p><a href="https://github.com/Computer-Tsu/ShackDesk-PortPane/blob/dev/OFFICIAL_BUILDS_AND_SERVICES.md" target="_blank" rel="noopener">Official Builds and Services</a></p>
+      </div>
+    </div>
+
+  </main>
+
+  <footer class="footer">
+    <div class="footer-inner">
+      <span>© 2025 Mark McDow, N4TEK — My Computer Guru LLC</span>
+      <ul class="footer-links">
+        <li><a href="/about/">About</a></li>
+        <li><a href="/faq/">FAQ</a></li>
+        <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="https://github.com/Computer-Tsu" target="_blank" rel="noopener">GitHub</a></li>
+        <li><a href="/sponsor">Sponsor</a></li>
+      </ul>
+    </div>
+  </footer>
+
+</body>
+</html>

--- a/portpane/index.html
+++ b/portpane/index.html
@@ -87,6 +87,10 @@
         <p><span class="label">Runtime</span><br>.NET 8 — included with Windows 11; auto-prompted on Windows 10 if needed</p>
         <hr>
         <p><span class="label">Source Code</span><br><a href="https://github.com/Computer-Tsu/ShackDesk-PortPane" target="_blank" rel="noopener" class="mono">github.com/Computer-Tsu/ShackDesk-PortPane</a></p>
+        <hr>
+        <p><span class="label">Source &amp; Services</span><br>Source code: MIT. Official ShackDesk builds, optional registration/personalization, and support are offered under separate commercial terms.</p>
+        <hr>
+        <p><span class="label">Code Signing Policy</span><br><a href="/portpane/code-signing-policy/">Read the PortPane code signing policy</a></p>
       </div>
     </div>
 

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -18,7 +18,7 @@
   <!-- Homepage -->
   <url>
     <loc>https://shackdesk.com/</loc>
-    <lastmod>2025-01-01</lastmod>
+    <lastmod>2026-04-20</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -26,9 +26,16 @@
   <!-- Product pages -->
   <url>
     <loc>https://shackdesk.com/portpane/</loc>
-    <lastmod>2026-04-08</lastmod>
+    <lastmod>2026-04-20</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
+  </url>
+
+  <url>
+    <loc>https://shackdesk.com/portpane/code-signing-policy/</loc>
+    <lastmod>2026-04-20</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
   </url>
 
   <url>
@@ -55,7 +62,7 @@
   <!-- About -->
   <url>
     <loc>https://shackdesk.com/about/</loc>
-    <lastmod>2025-01-01</lastmod>
+    <lastmod>2026-04-20</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.6</priority>
   </url>
@@ -63,7 +70,7 @@
   <!-- FAQ -->
   <url>
     <loc>https://shackdesk.com/faq/</loc>
-    <lastmod>2025-01-01</lastmod>
+    <lastmod>2026-04-20</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>


### PR DESCRIPTION
## Summary

- Update remaining commercial license references to reflect MIT + optional services model across site pages
- Add new PortPane code signing policy page at `/portpane/code-signing-policy/`
- Update FAQ to link to the code signing policy page with accurate current status
- Update sitemap with new page

## Files changed

- `index.html` — updated open source/licensing language
- `about/index.html` — updated GitHub/source language
- `faq/index.html` — updated code signing and licensing FAQ answers; link to new policy page
- `portpane/index.html` — added code signing policy link
- `portpane/code-signing-policy/index.html` — new page
- `sitemap.xml` — added new page entry

## Test plan

- [ ] `/portpane/code-signing-policy/` loads correctly
- [ ] FAQ links to code signing policy page
- [ ] Sitemap includes the new URL