### PR TITLE
fix: make RigCheck app card a clickable link to product page

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,14 +51,15 @@
           <div class="app-card-link">Learn more →</div>
         </a>
 
-        <div class="app-card muted">
+        <a href="/rigcheck/" class="app-card">
           <div class="app-card-name">
             RigCheck
             <span class="badge badge-dev">In development</span>
           </div>
           <div class="app-card-tagline">"Know your rig is ready."</div>
           <p class="app-card-desc">Serial CAT communication diagnostics using Hamlib. Verify your radio connection before it matters.</p>
-        </div>
+          <div class="app-card-link">Learn more →</div>
+        </a>
 
         <a href="/markmyspot/" class="app-card">
           <div class="app-card-name">MarkMySpot</div>


### PR DESCRIPTION
Converts the muted, non-interactive RigCheck card on the homepage to a proper anchor linking to /rigcheck/. Removes the muted class (and its pointer-events: none) and adds the Learn more arrow to match the other app cards.