### PR TITLE
fix: make RigCheck clickable and add MarkMySpot to PortPane suite section

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -46,14 +46,15 @@
           <div class="app-card-link">Learn more →</div>
         </a>
 
-        <div class="app-card muted">
+        <a href="/rigcheck/" class="app-card muted">
           <div class="app-card-name">
             RigCheck
             <span class="badge badge-dev">In development</span>
           </div>
           <div class="app-card-tagline">"Know your rig is ready."</div>
           <p class="app-card-desc">Serial CAT communication diagnostics using Hamlib.</p>
-        </div>
+          <div class="app-card-link">Learn more →</div>
+        </a>
 
         <a href="/markmyspot/" class="app-card">
           <div class="app-card-name">MarkMySpot</div>

--- a/markmyspot/index.html
+++ b/markmyspot/index.html
@@ -110,11 +110,12 @@
           <p class="app-card-desc">Audio device and COM port display and switching for digital mode operators.</p>
           <div class="app-card-link">Learn more →</div>
         </a>
-        <div class="app-card muted">
+        <a href="/rigcheck/" class="app-card muted">
           <div class="app-card-name">RigCheck <span class="badge badge-dev">In development</span></div>
           <div class="app-card-tagline">"Know your rig is ready."</div>
           <p class="app-card-desc">Serial CAT communication diagnostics using Hamlib.</p>
-        </div>
+          <div class="app-card-link">Learn more →</div>
+        </a>
       </div>
     </div>
 

--- a/portpane/index.html
+++ b/portpane/index.html
@@ -97,14 +97,21 @@
     <div class="section">
       <div class="section-label">Part of the ShackDesk Suite</div>
       <div class="app-grid">
-        <div class="app-card muted">
+        <a href="/markmyspot/" class="app-card">
+          <div class="app-card-name">MarkMySpot</div>
+          <div class="app-card-tagline">"Your location, in ham-friendly formats."</div>
+          <p class="app-card-desc">Maidenhead grid square, lat/lon, and DMS coordinates on any device. Installable PWA, no account required.</p>
+          <div class="app-card-link">Learn more →</div>
+        </a>
+        <a href="/rigcheck/" class="app-card muted">
           <div class="app-card-name">
             RigCheck
             <span class="badge badge-dev">In development</span>
           </div>
           <div class="app-card-tagline">"Know your rig is ready."</div>
           <p class="app-card-desc">Serial CAT communication diagnostics using Hamlib.</p>
-        </div>
+          <div class="app-card-link">Learn more →</div>
+        </a>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary

- **portpane/index.html** — adds MarkMySpot card; converts RigCheck `<div>` → `<a href="/rigcheck/">` (keeps `muted` + badge)
- **markmyspot/index.html** — converts RigCheck `<div>` → `<a href="/rigcheck/">` (keeps `muted` + badge)
- **about/index.html** — converts RigCheck `<div>` → `<a href="/rigcheck/">` (keeps `muted` + badge)

All RigCheck cards are still styled as muted/in-development but are now navigable. MarkMySpot was missing from the PortPane page's suite section; about/ already had it correctly.

## Test plan

- [ ] `/portpane/` suite section shows both MarkMySpot and RigCheck, both clickable
- [ ] `/markmyspot/` suite section RigCheck card links to `/rigcheck/`
- [ ] `/about/` suite section RigCheck card links to `/rigcheck/`
- [ ] RigCheck cards still appear visually muted with the "In development" badge