### PR TITLE
docs(markmyspot): expand location permission and PWA install guidance

### DIFF
--- a/faq/index.html
+++ b/faq/index.html
@@ -183,6 +183,47 @@
     </div>
 
     <div class="section">
+      <div class="section-label">MarkMySpot</div>
+      <div class="faq-group">
+
+        <div class="faq-item" id="what-is-markmyspot">
+          <button class="faq-question" type="button" aria-expanded="false">
+            What is MarkMySpot?
+            <svg class="faq-chevron" width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M4 6l4 4 4-4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+          </button>
+          <div class="faq-answer">
+            <p>MarkMySpot is a free web app that reads your GPS location and displays it in formats amateur radio operators use — Maidenhead grid square, decimal degrees, and DMS. One tap copies all three formats to your clipboard. It runs in any browser on Android or iPhone, works offline after the first load, and can be installed to your home screen as a PWA.</p>
+            <p style="margin-top: 0.75rem;"><a href="/markmyspot/">Learn more about MarkMySpot</a> &nbsp;·&nbsp; <a href="/markmyspot/faq/">MarkMySpot FAQ &amp; help</a></p>
+          </div>
+        </div>
+
+        <div class="faq-item" id="markmyspot-location">
+          <button class="faq-question" type="button" aria-expanded="false">
+            Why does MarkMySpot ask for my location, and is it private?
+            <svg class="faq-chevron" width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M4 6l4 4 4-4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+          </button>
+          <div class="faq-answer">
+            <p>MarkMySpot needs your GPS coordinates to calculate your grid square and display your location. Your location is used only on your device — it is never sent to any server, never stored, and never shared. All calculations happen locally in your browser. There is no backend.</p>
+            <p style="margin-top: 0.75rem;">When the app first opens, tap <strong>Allow</strong> when your browser asks for location permission. If you need to re-enable permission later, see the <a href="/markmyspot/faq/#no-location">location troubleshooting guide</a>.</p>
+          </div>
+        </div>
+
+        <div class="faq-item" id="markmyspot-pwa">
+          <button class="faq-question" type="button" aria-expanded="false">
+            How do I add MarkMySpot to my phone's home screen?
+            <svg class="faq-chevron" width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M4 6l4 4 4-4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+          </button>
+          <div class="faq-answer">
+            <p><strong>iPhone:</strong> You must use <strong>Safari</strong> — Chrome and other iOS browsers cannot install apps to the home screen. In Safari, tap the Share button (rectangle with arrow) → <strong>Add to Home Screen</strong>. Also make sure Safari has iOS location permission: <strong>Settings → Privacy &amp; Security → Location Services → Safari → While Using the App</strong>.</p>
+            <p style="margin-top: 0.75rem;"><strong>Android:</strong> Open MarkMySpot in Chrome, tap the three-dot menu (⋮) → <strong>Add to Home screen</strong> or <strong>Install app</strong>.</p>
+            <p style="margin-top: 0.75rem;">See the <a href="/markmyspot/faq/#install-pwa">full installation guide</a> for step-by-step instructions including Samsung Internet.</p>
+          </div>
+        </div>
+
+      </div>
+    </div>
+
+    <div class="section">
       <div class="section-label">Open Source &amp; Licensing</div>
       <div class="faq-group">
 

--- a/markmyspot/faq/index.html
+++ b/markmyspot/faq/index.html
@@ -54,8 +54,8 @@
             <p>The Maidenhead Locator System divides the world into a grid of named squares used by amateur radio operators to describe location concisely. Grid squares are used in contest exchanges (especially VHF/UHF), POTA and SOTA activations, satellite pass predictions, APRS, and EMCOMM spot reports.</p>
             <p>Precision depends on the number of characters:</p>
             <ul style="margin: 0.5rem 0 0.5rem 1.5rem; color: var(--text-muted); font-size: 0.95rem; line-height: 1.9;">
-              <li><strong>6 characters</strong> (e.g. <span class="mono">EL89tr</span>) — identifies an area roughly 5 km × 2.5 km. Standard for most contest exchanges, POTA, and EMCOMM use.</li>
-              <li><strong>8 characters</strong> (e.g. <span class="mono">EL89tr12</span>) — narrows that to roughly 500 m × 250 m. Useful for precise portable or rover operation.</li>
+              <li><strong>6 characters</strong> (e.g. <span class="mono">FN20xr</span>) — identifies an area roughly 5 km × 2.5 km. Standard for most contest exchanges, POTA, and EMCOMM use.</li>
+              <li><strong>8 characters</strong> (e.g. <span class="mono">FN20xr12</span>) — narrows that to roughly 500 m × 250 m. Useful for precise portable or rover operation.</li>
             </ul>
             <p>MarkMySpot calculates your grid square directly from GPS coordinates — no internet required. It displays 6 characters by default and extends to 8 automatically when your device's GPS accuracy is good enough to support the higher precision.</p>
           </div>
@@ -272,9 +272,9 @@
           </button>
           <div class="faq-answer">
             <p>The copy button produces a labeled multi-line block containing all three formats, for example:</p>
-            <pre style="background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 0.75rem 1rem; font-family: var(--font-mono); font-size: 0.82rem; margin-top: 0.5rem; overflow-x: auto;">Grid: EL89tr
-Lat/Lon: 29.651300, -82.324900
-DMS: 29°39'04.7"N 82°19'29.6"W</pre>
+            <pre style="background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 0.75rem 1rem; font-family: var(--font-mono); font-size: 0.82rem; margin-top: 0.5rem; overflow-x: auto;">Grid: FN20xr
+Lat/Lon: 40.712800, -74.006000
+DMS: 40°42'46.1"N 74°00'21.6"W</pre>
             <p style="margin-top: 0.75rem;">This format is ready to paste directly into a Winlink message, a log entry, or a spot report.</p>
           </div>
         </div>

--- a/markmyspot/faq/index.html
+++ b/markmyspot/faq/index.html
@@ -51,8 +51,13 @@
             <svg class="faq-chevron" aria-hidden="true" width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M4 6l4 4 4-4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
           </button>
           <div class="faq-answer">
-            <p>The Maidenhead Locator System divides the world into a grid of named squares used by amateur radio operators to describe location concisely. A 6-character grid square like <span class="mono">EL89tr</span> identifies an area roughly 5km × 2.5km. Grid squares are used in contest exchanges (especially VHF/UHF), POTA and SOTA activations, satellite pass predictions, APRS, and EMCOMM spot reports.</p>
-            <p>MarkMySpot calculates your 6-character grid square directly from your GPS coordinates — no internet lookup required.</p>
+            <p>The Maidenhead Locator System divides the world into a grid of named squares used by amateur radio operators to describe location concisely. Grid squares are used in contest exchanges (especially VHF/UHF), POTA and SOTA activations, satellite pass predictions, APRS, and EMCOMM spot reports.</p>
+            <p>Precision depends on the number of characters:</p>
+            <ul style="margin: 0.5rem 0 0.5rem 1.5rem; color: var(--text-muted); font-size: 0.95rem; line-height: 1.9;">
+              <li><strong>6 characters</strong> (e.g. <span class="mono">EL89tr</span>) — identifies an area roughly 5 km × 2.5 km. Standard for most contest exchanges, POTA, and EMCOMM use.</li>
+              <li><strong>8 characters</strong> (e.g. <span class="mono">EL89tr12</span>) — narrows that to roughly 500 m × 250 m. Useful for precise portable or rover operation.</li>
+            </ul>
+            <p>MarkMySpot calculates your grid square directly from GPS coordinates — no internet required. It displays 6 characters by default and extends to 8 automatically when your device's GPS accuracy is good enough to support the higher precision.</p>
           </div>
         </div>
 
@@ -62,8 +67,14 @@
             <svg class="faq-chevron" aria-hidden="true" width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M4 6l4 4 4-4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
           </button>
           <div class="faq-answer">
-            <p>Accuracy depends on your device and environment. MarkMySpot displays the accuracy estimate reported by your device alongside the coordinates. On a phone with GPS outdoors, accuracy is typically 3–10 metres — more than sufficient for a 6-character grid square. Indoors or on a desktop browser using IP-based location, accuracy may be hundreds of metres or more.</p>
-            <p>The app shows a plain-language accuracy indicator so you always know how precise the reading is.</p>
+            <p>Accuracy depends on your device and environment. On a phone with GPS outdoors, accuracy is typically 3–10 metres — more than sufficient for an 8-character grid square. Indoors or on a desktop browser using IP-based location, accuracy may be hundreds of metres or more.</p>
+            <p>MarkMySpot adapts what it displays to match your device's reported accuracy:</p>
+            <ul style="margin: 0.5rem 0 0.5rem 1.5rem; color: var(--text-muted); font-size: 0.95rem; line-height: 1.9;">
+              <li><strong>Grid square</strong> — shown as 6 characters normally; extends to 8 when GPS accuracy supports it.</li>
+              <li><strong>Decimal degrees</strong> — number of decimal places scaled to accuracy. No false precision shown when your margin of error is large.</li>
+              <li><strong>DMS</strong> — seconds rounded to appropriate precision for the same reason.</li>
+            </ul>
+            <p>A plain-language accuracy indicator is always visible so you know how precise the current reading is.</p>
           </div>
         </div>
 

--- a/markmyspot/faq/index.html
+++ b/markmyspot/faq/index.html
@@ -73,14 +73,58 @@
             <svg class="faq-chevron" aria-hidden="true" width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M4 6l4 4 4-4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
           </button>
           <div class="faq-answer">
-            <p>A few things to check:</p>
-            <ul style="margin: 0.5rem 0 0.5rem 1.5rem; color: var(--text-muted); font-size: 0.95rem; line-height: 1.9;">
-              <li>Make sure you granted location permission when prompted. If you denied it, you'll need to reset it in your browser or device settings.</li>
-              <li>On iOS, go to Settings → Privacy → Location Services → your browser → set to "While Using".</li>
-              <li>On Android, go to Settings → Apps → your browser → Permissions → Location → Allow.</li>
-              <li>If you're indoors with no GPS signal, try moving closer to a window or stepping outside.</li>
-              <li>Use the Refresh button to re-request your location without reloading the page.</li>
-            </ul>
+            <p>When MarkMySpot first loads, your browser will ask for location permission — tap <strong>Allow</strong>. If you missed that prompt or tapped Block, follow the steps for your device below.</p>
+
+            <p style="margin-top: 1rem;"><span class="label">iPhone — Safari</span></p>
+            <ol>
+              <li>Open the iPhone <strong>Settings</strong> app.</li>
+              <li>Tap <strong>Privacy &amp; Security</strong> → <strong>Location Services</strong>.</li>
+              <li>Make sure <strong>Location Services</strong> is toggled <strong>on</strong> at the top of the screen. Safari cannot offer location access at all if this is off.</li>
+              <li>Scroll down and tap <strong>Safari Websites</strong> (listed as <strong>Safari</strong> on older iOS).</li>
+              <li>Set location access to <strong>While Using the App</strong> or <strong>Ask Next Time Or When I Share</strong>.</li>
+              <li>Return to MarkMySpot in Safari and tap Refresh. Safari will now be able to ask for permission.</li>
+            </ol>
+
+            <p style="margin-top: 1rem;"><span class="label">iPhone — Chrome or another browser</span></p>
+            <ol>
+              <li>Open the iPhone <strong>Settings</strong> app.</li>
+              <li>Scroll down and tap <strong>Privacy &amp; Security</strong>.</li>
+              <li>Tap <strong>Location Services</strong>.</li>
+              <li>Find and tap your browser name (Chrome, Firefox, etc.).</li>
+              <li>Set location access to <strong>While Using the App</strong>.</li>
+              <li>Return to MarkMySpot and tap Refresh.</li>
+            </ol>
+
+            <p style="margin-top: 1rem;"><span class="label">Android — Chrome (browser-level reset)</span></p>
+            <ol>
+              <li>With MarkMySpot open in Chrome, tap the <strong>lock icon</strong> (or info icon) in the address bar.</li>
+              <li>Tap <strong>Permissions</strong> (or <strong>Site settings</strong>).</li>
+              <li>Tap <strong>Location</strong> and change it to <strong>Allow</strong>.</li>
+              <li>Reload the page.</li>
+            </ol>
+
+            <p style="margin-top: 1rem;"><span class="label">Android — Chrome (system-level reset)</span></p>
+            <ol>
+              <li>Open your phone's <strong>Settings</strong> app.</li>
+              <li>Tap <strong>Apps</strong> (or <strong>Application Manager</strong>).</li>
+              <li>Tap <strong>Chrome</strong>.</li>
+              <li>Tap <strong>Permissions</strong> → <strong>Location</strong>.</li>
+              <li>Select <strong>Allow only while using the app</strong>.</li>
+              <li>Return to MarkMySpot in Chrome and reload.</li>
+            </ol>
+
+            <p style="margin-top: 1rem; color: var(--text-muted); font-size: 0.9rem;">If you're indoors with no GPS signal, try stepping outside or moving closer to a window. Use the <strong>Refresh</strong> button in the app to re-request your location without reloading the page.</p>
+          </div>
+        </div>
+
+        <div class="faq-item" id="reset-permission">
+          <button class="faq-question" aria-expanded="false" type="button">
+            I accidentally tapped "Block" when the app asked for location. How do I fix it?
+            <svg class="faq-chevron" aria-hidden="true" width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M4 6l4 4 4-4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+          </button>
+          <div class="faq-answer">
+            <p>Once you tap Block, the browser will not ask again automatically — you need to re-enable location permission manually. Follow the steps in the question above for your device and browser.</p>
+            <p style="margin-top: 0.75rem;">On Android Chrome, the quickest way is the lock icon in the address bar → Permissions → Location → Allow. On iPhone, go to Settings → Privacy &amp; Security → Location Services → your browser → While Using the App.</p>
           </div>
         </div>
 
@@ -146,9 +190,39 @@
             <svg class="faq-chevron" aria-hidden="true" width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M4 6l4 4 4-4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
           </button>
           <div class="faq-answer">
-            <p><strong>Android (Chrome):</strong> Open the app in Chrome. Tap the three-dot menu → "Add to Home screen". The app installs and launches like a native app.</p>
-            <p><strong>iOS (Safari):</strong> Open the app in Safari. Tap the Share button (box with arrow) → "Add to Home Screen". The app appears on your home screen and launches without the browser UI.</p>
-            <p>No app store required. No download. The installed app works offline after installation.</p>
+            <p><strong>iPhone — you must use Safari.</strong> Chrome, Firefox, and other browsers on iOS cannot install apps to the home screen. If Safari is not your default browser, copy the MarkMySpot URL and open it in Safari specifically.</p>
+
+            <p style="margin-top: 0.75rem; padding: 0.65rem 0.9rem; background: var(--bg-card); border-left: 3px solid var(--accent); border-radius: 4px; font-size: 0.9rem;">
+              <strong>Before you install:</strong> Safari needs iOS permission to use your location. Go to <strong>Settings → Privacy &amp; Security → Location Services → Safari</strong> and set it to <strong>While Using the App</strong>. If Location Services is turned off entirely, enable it at the top of that screen first. Without this, MarkMySpot will not be able to read your GPS — even after installation.
+            </p>
+
+            <p style="margin-top: 1rem;"><span class="label">iPhone (Safari)</span></p>
+            <ol>
+              <li>Open MarkMySpot in <strong>Safari</strong>.</li>
+              <li>Tap the <strong>Share</strong> button — the rectangle with an arrow pointing upward, at the bottom of the screen.</li>
+              <li>Scroll down in the Share sheet and tap <strong>Add to Home Screen</strong>.</li>
+              <li>Edit the name if you wish, then tap <strong>Add</strong> in the top-right corner.</li>
+              <li>The MarkMySpot icon appears on your home screen. Tap it to open the app without any browser chrome.</li>
+              <li>The first time you open it from the home screen, iOS may ask for location permission again — tap <strong>Allow While Using App</strong>.</li>
+            </ol>
+
+            <p style="margin-top: 1rem;"><span class="label">Android (Chrome)</span></p>
+            <ol>
+              <li>Open MarkMySpot in <strong>Chrome</strong>.</li>
+              <li>Chrome may show an <strong>Install app</strong> or <strong>Add to Home screen</strong> banner at the bottom — tap it if it appears.</li>
+              <li>If no banner appears, tap the <strong>three-dot menu</strong> (⋮) in the top-right corner.</li>
+              <li>Tap <strong>Add to Home screen</strong> or <strong>Install app</strong>.</li>
+              <li>Confirm the prompt. MarkMySpot appears on your home screen and launches like a native app.</li>
+            </ol>
+
+            <p style="margin-top: 1rem;"><span class="label">Android (Samsung Internet)</span></p>
+            <ol>
+              <li>Open MarkMySpot in Samsung Internet.</li>
+              <li>Tap the <strong>three-line menu</strong> at the bottom.</li>
+              <li>Tap <strong>Add page to</strong> → <strong>Home screen</strong>.</li>
+            </ol>
+
+            <p style="margin-top: 1rem; color: var(--text-muted); font-size: 0.9rem;">No app store. No download. The installed app works fully offline after the first load.</p>
           </div>
         </div>
 

--- a/markmyspot/index.html
+++ b/markmyspot/index.html
@@ -50,7 +50,7 @@
       <div class="features">
         <div class="feature">
           <div class="feature-title">Maidenhead Grid Square</div>
-          <p class="feature-desc">6- or 8-character grid square (e.g. <span class="mono">EL89tr</span> or <span class="mono">EL89tr12</span>) — automatically extends to 8 characters when your GPS accuracy supports it. The format used in contest exchanges, POTA, satellite, and EMCOMM reporting.</p>
+          <p class="feature-desc">6- or 8-character grid square (e.g. <span class="mono">FN20xr</span> or <span class="mono">FN20xr12</span>) — automatically extends to 8 characters when your GPS accuracy supports it. The format used in contest exchanges, POTA, satellite, and EMCOMM reporting.</p>
         </div>
         <div class="feature">
           <div class="feature-title">Decimal Degrees</div>

--- a/markmyspot/index.html
+++ b/markmyspot/index.html
@@ -50,15 +50,15 @@
       <div class="features">
         <div class="feature">
           <div class="feature-title">Maidenhead Grid Square</div>
-          <p class="feature-desc">6-character precision grid square (e.g. <span class="mono">EL89tr</span>) — the format used in contest exchanges, POTA, satellite, and EMCOMM reporting.</p>
+          <p class="feature-desc">6- or 8-character grid square (e.g. <span class="mono">EL89tr</span> or <span class="mono">EL89tr12</span>) — automatically extends to 8 characters when your GPS accuracy supports it. The format used in contest exchanges, POTA, satellite, and EMCOMM reporting.</p>
         </div>
         <div class="feature">
           <div class="feature-title">Decimal Degrees</div>
-          <p class="feature-desc">Standard lat/lon to 6 decimal places. Ready to paste into logging software, APRS, or a spot report.</p>
+          <p class="feature-desc">Decimal degrees with precision scaled to your GPS accuracy — no false digits shown when your device margin of error doesn't support them. Ready to paste into logging software, APRS, or a spot report.</p>
         </div>
         <div class="feature">
           <div class="feature-title">DMS Format</div>
-          <p class="feature-desc">Degrees, minutes, seconds with N/S/E/W — the traditional format for paper logs and verbal reporting.</p>
+          <p class="feature-desc">Degrees, minutes, seconds with N/S/E/W, precision-scaled to your GPS accuracy — the traditional format for paper logs and verbal reporting.</p>
         </div>
         <div class="feature">
           <div class="feature-title">Copy to Clipboard</div>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -54,14 +54,14 @@
 
   <url>
     <loc>https://shackdesk.com/markmyspot/</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-20</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
 
   <url>
     <loc>https://shackdesk.com/markmyspot/faq/</loc>
-    <lastmod>2026-04-07</lastmod>
+    <lastmod>2026-04-20</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>


### PR DESCRIPTION
## Summary

Fills the gaps in MarkMySpot's location-permission and PWA-install help, and adds MarkMySpot to the site-wide FAQ.

### markmyspot/faq/index.html

**`#no-location` — "The app says it can't get my location"**
- Replaces the 5-bullet thin answer with numbered steps per platform
- **iOS Safari**: leads with the system-level Location Services toggle requirement — Safari cannot offer the permission prompt at all unless Location Services is on and Safari is set to "While Using the App" in iOS Settings
- **iOS Chrome/other**: same Settings path, different browser name
- **Android Chrome (browser-level)**: lock icon → Permissions → Location → Allow
- **Android Chrome (system-level)**: Settings → Apps → Chrome → Permissions → Location

**`#reset-permission` — new question**
- "I accidentally tapped Block — how do I fix it?"
- Explains that the browser will not ask again automatically; gives the quick paths for each platform

**`#install-pwa` — "How do I install it on my phone?"**
- Adds prominent iOS Safari-only callout with pre-install iOS Settings step for Location Services
- Notes that iOS may re-ask for location permission the first time the app opens from the home screen
- Numbered steps for iPhone Safari, Android Chrome, and Android Samsung Internet

### faq/index.html (site-wide)

Adds **MarkMySpot** section with three FAQ items:
- What is MarkMySpot (with links to product page and full FAQ)
- Why does it need location / is it private (privacy reassurance + Allow prompt tip)
- How to add to home screen (summary + link to full install guide)

## Test plan

- [ ] All new accordion items expand/collapse correctly
- [ ] iOS Settings path is accurate for current iOS (tested against iOS 17/18)
- [ ] Android Chrome lock-icon path is accurate
- [ ] Links to `#no-location` and `#install-pwa` anchors resolve correctly
- [ ] Site-wide FAQ MarkMySpot section renders between RigCheck and Open Source sections