### PR TITLE
fix: remove muted class from RigCheck app cards

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -46,7 +46,7 @@
           <div class="app-card-link">Learn more →</div>
         </a>
 
-        <a href="/rigcheck/" class="app-card muted">
+        <a href="/rigcheck/" class="app-card">
           <div class="app-card-name">
             RigCheck
             <span class="badge badge-dev">In development</span>

--- a/markmyspot/index.html
+++ b/markmyspot/index.html
@@ -110,7 +110,7 @@
           <p class="app-card-desc">Audio device and COM port display and switching for digital mode operators.</p>
           <div class="app-card-link">Learn more →</div>
         </a>
-        <a href="/rigcheck/" class="app-card muted">
+        <a href="/rigcheck/" class="app-card">
           <div class="app-card-name">RigCheck <span class="badge badge-dev">In development</span></div>
           <div class="app-card-tagline">"Know your rig is ready."</div>
           <p class="app-card-desc">Serial CAT communication diagnostics using Hamlib.</p>

--- a/portpane/index.html
+++ b/portpane/index.html
@@ -103,7 +103,7 @@
           <p class="app-card-desc">Maidenhead grid square, lat/lon, and DMS coordinates on any device. Installable PWA, no account required.</p>
           <div class="app-card-link">Learn more →</div>
         </a>
-        <a href="/rigcheck/" class="app-card muted">
+        <a href="/rigcheck/" class="app-card">
           <div class="app-card-name">
             RigCheck
             <span class="badge badge-dev">In development</span>


### PR DESCRIPTION
## Summary

- Removes `muted` class from RigCheck `<a>` cards on `portpane/index.html`, `markmyspot/index.html`, and `about/index.html`
- `.app-card.muted` in CSS has `pointer-events: none`, which blocked all clicks even though these are now proper `<a>` tags pointing to `/rigcheck/`
- The "In development" badge inside each card still communicates status visually

## Test plan

- [ ] Visit https://shackdesk.com/portpane/ — scroll to "Part of the ShackDesk Suite", click RigCheck card → should navigate to `/rigcheck/`
- [ ] Visit https://shackdesk.com/markmyspot/ — same check
- [ ] Visit https://shackdesk.com/about/ — same check
- [ ] Confirm MarkMySpot and PortPane cards on those pages are unaffected